### PR TITLE
fix: avoid shelling out for package version resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - Added unit tests covering suffix-match behavior and a pagination lookup test.
 - Migrate project ignore globs from `.eslintignore` into `eslint.config.js` `ignores` to remove deprecation warnings.
 - Remove several thin wrapper files and unused test helpers; centralize imports to inner modules (`./services/fetch`, `./ui/*`).
+- Fix issue #38 by resolving installed package versions from local package manifests instead of shelling out to npm/pnpm/yarn/bun at runtime.
+- Add regression tests for package version resolution, including missing-package retries and cache refresh behavior.
 
 ### Notes
 

--- a/src/services/package-version.ts
+++ b/src/services/package-version.ts
@@ -1,0 +1,50 @@
+import fsp from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import process from 'node:process'
+import { getRootPath } from '@vscode-use/utils'
+
+const packageVersionCache = new Map<string, string>()
+
+function getBasePath(resolveFrom?: string) {
+  if (!resolveFrom)
+    return getRootPath() || process.cwd()
+
+  return path.extname(resolveFrom)
+    ? path.dirname(resolveFrom)
+    : resolveFrom
+}
+
+export async function resolveInstalledPackageVersion(pkgName: string, resolveFrom?: string) {
+  if (!pkgName)
+    return
+
+  const basePath = getBasePath(resolveFrom)
+  const cacheKey = `${basePath}::${pkgName}`
+  if (packageVersionCache.has(cacheKey))
+    return packageVersionCache.get(cacheKey)
+
+  const requireBase = path.resolve(basePath, 'package.json')
+  const require = createRequire(requireBase)
+  let pkgJsonPath = ''
+
+  try {
+    pkgJsonPath = require.resolve(`${pkgName}/package.json`)
+  }
+  catch {
+    return
+  }
+
+  try {
+    const pkgJson = JSON.parse(await fsp.readFile(pkgJsonPath, 'utf-8'))
+    const version = typeof pkgJson?.version === 'string' ? pkgJson.version : undefined
+    if (version)
+      packageVersionCache.set(cacheKey, version)
+    return version
+  }
+  catch {}
+}
+
+export function clearPackageVersionCache() {
+  packageVersionCache.clear()
+}

--- a/src/services/ui-cache.ts
+++ b/src/services/ui-cache.ts
@@ -1,4 +1,5 @@
 import type { ComponentsConfig, PropsConfig, Uis } from '../ui/types'
+import { clearPackageVersionCache } from './package-version'
 
 export const cacheMap = new Map<string, ComponentsConfig | PropsConfig>()
 export const pkgUIConfigMap = new Map<string, { propsConfig: PropsConfig, componentsConfig: ComponentsConfig }>()
@@ -10,6 +11,7 @@ export function clearUICache() {
   pkgUIConfigMap.clear()
   urlCache.clear()
   rootPkgCache.clear()
+  clearPackageVersionCache()
 }
 
 export function getCacheMap() {

--- a/src/ui/ui-find.ts
+++ b/src/ui/ui-find.ts
@@ -5,10 +5,10 @@ import { createLog, getActiveText, getCurrentFileUrl, getRootPath, watchFile } f
 import { findUp } from 'find-up'
 import { UINames as configUINames } from '../constants'
 import { cacheFetch, fetchFromCommonIntellisense, fetchFromLocalUris, fetchFromRemoteNpmUrls, fetchFromRemoteUrls, getLocalCache, localCacheUri } from '../services/fetch'
+import { resolveInstalledPackageVersion } from '../services/package-version'
 import { formatUIName, getAlias, getIsShowSlots, getPrefix, getSelectedUIs, getUiDeps } from './ui-utils'
 import { cacheMap, pkgUIConfigMap, rootPkgCache, urlCache } from '../services/ui-cache'
 import path from 'node:path'
-import { getLibVersion } from 'get-lib-version'
 import { clearTypeCache } from '../type-extract/cache'
 
 export const logger = createLog('common-intellisense')
@@ -324,7 +324,7 @@ export async function findPkgUI(cwd?: string, onChange?: () => void) {
         else {
           // resolve from the package that declares the dependency if possible
           const resolveFrom = depSource[key] || pkgDir || path.resolve(pkg, '..')
-          fixedVersion = await getLibVersion(key, resolveFrom)
+          fixedVersion = await resolveInstalledPackageVersion(key, resolveFrom)
         }
       }
       if (!fixedVersion) {

--- a/src/ui/utils.ts
+++ b/src/ui/utils.ts
@@ -5,8 +5,8 @@ import { camelize, compareVersion, isContainCn, reduceAsync, replaceAsync } from
 import { createCompletionItem, createHover, createMarkdownString, getActiveTextEditorLanguageId, getConfiguration, getCurrentFileUrl, getLocale, getRootPath, setCommandParams } from '@vscode-use/utils'
 import * as vscode from 'vscode'
 import { translate } from '../translate'
+import { resolveInstalledPackageVersion } from '../services/package-version'
 import { logger } from '../ui/ui-find'
-import { getLibVersion } from 'get-lib-version'
 
 export interface PropsOptions {
   uiName: string
@@ -87,7 +87,7 @@ export function propsReducer(options: PropsOptions) {
     const isZh = getLocale().includes('zh')
     if (!localVersion) {
       // 从本地安装去获取版本号，如果获取不到根据 uiName 后缀获取版本号，再找不到就是 0.0.0
-      localVersion = await getLibVersion(lib, cwd) || uiName.match(/\d+(\.\d+\.\d+)?/)?.[0] || '0.0.0'
+      localVersion = await resolveInstalledPackageVersion(lib, cwd) || uiName.match(/\d+(\.\d+\.\d+)?/)?.[0] || '0.0.0'
     }
 
     if (item.version) {

--- a/test/services/package-version.test.ts
+++ b/test/services/package-version.test.ts
@@ -1,0 +1,68 @@
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { clearPackageVersionCache, resolveInstalledPackageVersion } from '../../src/services/package-version'
+
+describe('package-version service', () => {
+  let tempDir = ''
+
+  beforeEach(async () => {
+    clearPackageVersionCache()
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'common-intellisense-'))
+    await fsp.writeFile(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'fixture' }))
+  })
+
+  afterEach(async () => {
+    clearPackageVersionCache()
+    if (tempDir)
+      await fsp.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('resolves installed package versions from local package manifests', async () => {
+    const pkgDir = path.join(tempDir, 'node_modules', 'element-plus')
+    await fsp.mkdir(pkgDir, { recursive: true })
+    await fsp.writeFile(path.join(pkgDir, 'package.json'), JSON.stringify({
+      name: 'element-plus',
+      version: '2.9.7',
+    }))
+
+    await expect(resolveInstalledPackageVersion('element-plus', tempDir)).resolves.toBe('2.9.7')
+  })
+
+  it('does not cache missing packages', async () => {
+    await expect(resolveInstalledPackageVersion('element-plus', tempDir)).resolves.toBeUndefined()
+
+    const pkgDir = path.join(tempDir, 'node_modules', 'element-plus')
+    await fsp.mkdir(pkgDir, { recursive: true })
+    await fsp.writeFile(path.join(pkgDir, 'package.json'), JSON.stringify({
+      name: 'element-plus',
+      version: '2.9.7',
+    }))
+
+    await expect(resolveInstalledPackageVersion('element-plus', tempDir)).resolves.toBe('2.9.7')
+  })
+
+  it('returns refreshed versions after clearing the cache', async () => {
+    const pkgDir = path.join(tempDir, 'node_modules', 'element-plus')
+    const manifestPath = path.join(pkgDir, 'package.json')
+    await fsp.mkdir(pkgDir, { recursive: true })
+    await fsp.writeFile(manifestPath, JSON.stringify({
+      name: 'element-plus',
+      version: '2.9.7',
+    }))
+
+    await expect(resolveInstalledPackageVersion('element-plus', tempDir)).resolves.toBe('2.9.7')
+
+    await fsp.writeFile(manifestPath, JSON.stringify({
+      name: 'element-plus',
+      version: '2.9.8',
+    }))
+
+    await expect(resolveInstalledPackageVersion('element-plus', tempDir)).resolves.toBe('2.9.7')
+
+    clearPackageVersionCache()
+
+    await expect(resolveInstalledPackageVersion('element-plus', tempDir)).resolves.toBe('2.9.8')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #38 by replacing runtime package version lookups that shell out to npm/pnpm/yarn/bun with local package manifest resolution.
Also clears the version cache with the UI cache and adds regression tests for installed, missing, and refreshed package-version behavior.

## Checklist
- [x] I have run tests locally (vitest) and they pass.
- [x] I have run `pnpm run build` and `pnpm run typecheck` locally.
- [x] The changelog entry (if relevant) has been added.
- [ ] I have added reviewers or assignees if appropriate.

## Notes for reviewers
- Pay attention to `src/services/package-version.ts`, `src/ui/ui-find.ts`, and `src/ui/utils.ts` for the runtime version-resolution path.
- `test/services/package-version.test.ts` covers the regression cases for missing packages, resolved versions, and cache refresh behavior.
