### PR TITLE
fix: handle issue 40 regressions

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -763,8 +763,9 @@ export function registerCodeLensProviderFn() {
             else if (c.tag && c.props) {
               for (const p of c.props) {
                 if (p.name === 'slot') {
-                  const slotName = p.arg ? p.arg.content : p.value.content
-                  filters.push(slotName)
+                  const slotName = p.arg?.content || p.value?.content
+                  if (slotName)
+                    filters.push(slotName)
                   break
                 }
               }
@@ -772,8 +773,9 @@ export function registerCodeLensProviderFn() {
             else if (c.codegenNode?.tag && c.codegenNode.props) {
               for (const p of c.codegenNode.props) {
                 if (p.name === 'slot') {
-                  const slotName = p.arg ? p.arg.content : p.value.content
-                  filters.push(slotName)
+                  const slotName = p.arg?.content || p.value?.content
+                  if (slotName)
+                    filters.push(slotName)
                   break
                 }
               }

--- a/src/ui/utils.ts
+++ b/src/ui/utils.ts
@@ -115,7 +115,7 @@ export function propsReducer(options: PropsOptions) {
             const value = (item.props as any)[key]
             // value.version 只提取版本号
             const version = value.version?.match(/\d+\.\d+\.\d+/)?.[0]
-            if (version && compareVersion(version, localVersion!) === -1) {
+            if (version && compareVersion(version, localVersion!) === 1) {
               return result
             }
             return { ...result, [key]: value }
@@ -257,8 +257,8 @@ export function propsReducer(options: PropsOptions) {
         else {
           content = `${key}=""`
 
-          if (value.type.includes('/'))
-            snippet = `${key}="\${1|${value.type.split('/').map((i: string) => i.replace(/['`\s]/g, '').replace(/,/g, '\\,')).join(',')}|}"`
+          if (value.type?.includes('/'))
+            snippet = `${key}="\${1|${value.type.split('/').map((i: string) => i.replace(/['"`\s]/g, '').replace(/,/g, '\\,')).filter((i: string) => i.length).join(',')}|}"`
           else
             snippet = `${key}="\${1}"`
         }
@@ -334,7 +334,7 @@ export function propsReducer(options: PropsOptions) {
         const filterEvents = localVersion
           ? item.events.filter((event) => {
               const version = event.version?.match(/\d+\.\d+\.\d+/)?.[0]
-              return !(version && compareVersion(version, localVersion!) === -1)
+              return !(version && compareVersion(version, localVersion!) === 1)
             })
           : item.events
 
@@ -408,7 +408,7 @@ export function propsReducer(options: PropsOptions) {
         ? item.methods.filter((item) => {
           // 过滤在某个版本才增加的新方法
             const version = item.version?.match(/\d+\.\d+\.\d+/)?.[0]
-            return !(version && compareVersion(version, localVersion!) === -1)
+            return !(version && compareVersion(version, localVersion!) === 1)
           })
         : item.methods
       methods.push(...filterMethods.map((method) => {
@@ -444,7 +444,7 @@ export function propsReducer(options: PropsOptions) {
         ? item.exposed.filter((item) => {
           // 过滤在某个版本才增加的新方法
             const version = item.version?.match(/\d+\.\d+\.\d+/)?.[0]
-            return !(version && compareVersion(version, localVersion!) === -1)
+            return !(version && compareVersion(version, localVersion!) === 1)
           })
         : item.exposed
       exposed.push(...filterExposed.map((expose) => {
@@ -480,7 +480,7 @@ export function propsReducer(options: PropsOptions) {
         ? item.slots.filter((item) => {
           // 过滤在某个版本才增加的新方法
             const version = item.version?.match(/\d+\.\d+\.\d+/)?.[0]
-            return !(version && compareVersion(version, localVersion!) === -1)
+            return !(version && compareVersion(version, localVersion!) === 1)
           })
         : item.slots
       filterSlots.forEach((slot) => {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -2,14 +2,22 @@ import { vi } from 'vitest'
 
 // Mock @vscode-use/utils to prevent loading the real extension helpers
 vi.mock('@vscode-use/utils', () => ({
+  createCompletionItem: (options: any) => ({ ...options }),
+  createHover: (documentation: any) => ({ documentation }),
+  createMarkdownString: () => ({
+    isTrusted: false,
+    supportHtml: false,
+    appendMarkdown: () => {},
+    appendCodeblock: () => {},
+  }),
   createRange: () => ({}),
-  getActiveText: () => '',
+  getActiveText: vi.fn(() => ''),
   getActiveTextEditor: () => null,
-  getActiveTextEditorLanguageId: () => '',
+  getActiveTextEditorLanguageId: vi.fn(() => ''),
   getConfiguration: () => null,
-  getCurrentFileUrl: () => '',
+  getCurrentFileUrl: vi.fn(() => ''),
   getLineText: () => '',
-  getLocale: () => 'en',
+  getLocale: vi.fn(() => 'en'),
   getPosition: () => ({ position: { line: 0, character: 0 } }),
   getSelection: () => ({ lineText: '' }),
   insertText: () => {},
@@ -17,10 +25,11 @@ vi.mock('@vscode-use/utils', () => ({
   openExternalUrl: () => {},
   registerCommand: () => {},
   registerCompletionItemProvider: () => {},
+  registerCodeLensProvider: vi.fn((_languages: any, provider: any) => provider),
   setCopyText: () => Promise.resolve(),
+  setCommandParams: (value: any) => encodeURIComponent(JSON.stringify(value)),
   updateText: () => {},
   addEventListener: () => () => {},
-  registerCodeLensProvider: () => {},
   createFilter: () => () => false,
   // logging helper used in ui-find
   createLog: (_name: string) => ({
@@ -54,6 +63,15 @@ vi.mock('vscode', () => {
   return {
     MarkdownString,
     Range,
+    CodeLens: class CodeLens {
+      range: any
+      command: any
+
+      constructor(range: any, command: any) {
+        this.range = range
+        this.command = command
+      }
+    },
     Uri: { file: (p: string) => ({ fsPath: p }) },
     CompletionItemKind: { Property: 10, Enum: 11, Event: 12 },
     Hover: class Hover {},

--- a/test/ui/issue-40.test.ts
+++ b/test/ui/issue-40.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { getActiveText, getActiveTextEditorLanguageId, getCurrentFileUrl } from '@vscode-use/utils'
+import { detectSlots, registerCodeLensProviderFn } from '../../src/parser'
+import { propsReducer } from '../../src/ui/utils'
+
+const mockActiveText = getActiveText as any
+const mockCurrentFileUrl = getCurrentFileUrl as any
+const mockLanguageId = getActiveTextEditorLanguageId as any
+
+afterEach(async () => {
+  mockActiveText.mockReturnValue('')
+  mockCurrentFileUrl.mockReturnValue('')
+  mockLanguageId.mockReturnValue('')
+  await detectSlots({}, {}, [])
+})
+
+describe('issue 40 regressions', () => {
+  it('keeps CodeLens working when a template slot has no value', async () => {
+    mockCurrentFileUrl.mockReturnValue('/fixtures/App.vue')
+    mockLanguageId.mockReturnValue('vue')
+    mockActiveText.mockReturnValue(`
+<template>
+  <MyComp>
+    <template slot></template>
+    <template slot="footer"></template>
+  </MyComp>
+</template>
+`)
+
+    await detectSlots({
+      MyComp: {
+        rawSlots: [
+          { name: 'default', description: 'default slot' },
+          { name: 'footer', description: 'footer slot' },
+          { name: 'header', description: 'header slot' },
+        ],
+      },
+    }, {}, [])
+
+    const provider = registerCodeLensProviderFn() as any
+    const lenses = provider.provideCodeLenses()
+
+    expect(lenses.map((lens: any) => lens.command.title)).toEqual([
+      'Slots: default',
+      'header',
+    ])
+  })
+
+  it('creates valid slash snippets and keeps only version-compatible members', async () => {
+    const result = await propsReducer({
+      uiName: 'fixture2.0.0',
+      lib: '__missing_package__',
+      map: [{
+        name: 'Demo',
+        props: {
+          placement: { default: '', value: '', type: '\'top\' / "bottom" / ' },
+          untyped: { default: '', value: '' },
+          oldProp: { default: '', value: '', type: 'string', version: '1.0.0' },
+          currentProp: { default: '', value: '', type: 'string', version: '2.0.0' },
+          futureProp: { default: '', value: '', type: 'string', version: '3.0.0' },
+        },
+        events: [
+          { name: 'old-event', version: '1.0.0' },
+          { name: 'current-event', version: '2.0.0' },
+          { name: 'future-event', version: '3.0.0' },
+        ],
+        methods: [
+          { name: 'oldMethod', version: '1.0.0' },
+          { name: 'currentMethod', version: '2.0.0' },
+          { name: 'futureMethod', version: '3.0.0' },
+        ],
+        exposed: [
+          { name: 'oldExpose', detail: '()', version: '1.0.0' },
+          { name: 'currentExpose', detail: '()', version: '2.0.0' },
+          { name: 'futureExpose', detail: '()', version: '3.0.0' },
+        ],
+        slots: [
+          { name: 'old-slot', version: '1.0.0' },
+          { name: 'current-slot', version: '2.0.0' },
+          { name: 'future-slot', version: '3.0.0' },
+        ],
+      }],
+    })
+
+    const completions = result.Demo.completions[0](true)
+    expect(completions.find(item => item.content === 'placement=""')?.snippet).toBe('placement="${1|top,bottom|}"')
+    expect(completions.find(item => item.content === 'untyped=""')?.snippet).toBe('untyped="${1}"')
+
+    const propContents = completions.map(item => item.content)
+    expect(propContents).toContain('oldProp=""')
+    expect(propContents).toContain('currentProp=""')
+    expect(propContents).not.toContain('futureProp=""')
+
+    const eventNames = result.Demo.events[0](true).map(item => (item as any).params[1])
+    expect(eventNames).toContain('old-event')
+    expect(eventNames).toContain('current-event')
+    expect(eventNames).not.toContain('future-event')
+
+    const methodContents = result.Demo.methods.map(item => item.content)
+    expect(methodContents).toContain('oldMethod')
+    expect(methodContents).toContain('currentMethod')
+    expect(methodContents).not.toContain('futureMethod')
+
+    const exposedContents = result.Demo.exposed.map(item => item.content)
+    expect(exposedContents).toContain('oldExpose')
+    expect(exposedContents).toContain('currentExpose')
+    expect(exposedContents).not.toContain('futureExpose')
+
+    const slotContents = result.Demo.slots.map(item => item.content)
+    expect(slotContents).toContain('slot="old-slot"')
+    expect(slotContents).toContain('slot="current-slot"')
+    expect(slotContents).not.toContain('slot="future-slot"')
+  })
+})


### PR DESCRIPTION
## Summary
- guard slot CodeLens filtering when `slot` has no value
- filter slash-separated snippet options to avoid trailing empty choices
- keep versioned props/events/methods/exposed/slots when their required version is <= local version

Closes #40

## Tests
- `pnpm exec vitest run test/ui/issue-40.test.ts test/ui/pagination-lookup.test.ts test/ui/suffix-match-preference.test.ts`
- `pnpm exec vitest run test/ui`
- `pnpm exec eslint src/parser.ts src/ui/utils.ts test/setup.ts test/ui/issue-40.test.ts`
- `git diff --check`

Note: `pnpm exec tsc --noEmit --pretty false` still fails on an existing unrelated error: `test/services/source-priority.test.ts` imports missing `mergeAdapterSources` from `src/services/fetch`.