### PR TITLE
Fix oversized UI hint markdown headings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -479,7 +479,7 @@ export async function activate(context: vscode.ExtensionContext) {
             if (item.params?.length) {
               documentation.appendCodeblock('\n')
               item.params.forEach((i) => {
-                documentation.appendMarkdown(`### 🌟 ${i.name}: \n`)
+                documentation.appendMarkdown(`**🌟 ${i.name}** \n`)
                 documentation.appendMarkdown(`- ${isZh ? '类型' : 'type'}: ${i.type}\n`)
                 documentation.appendMarkdown(`- ${isZh ? '描述' : 'description'}: ${isZh ? i.description_zh : i.description}\n`)
                 documentation.appendMarkdown(`- ${isZh ? '默认值' : 'default'}: ${i.default}\n`)
@@ -792,9 +792,9 @@ export async function activate(context: vscode.ExtensionContext) {
           if (!params)
             return
           const md = createMarkdownString()
-          md.appendMarkdown(`## ${target.lib} [${targetSlot.name}]\n`)
-          md.appendMarkdown(`#### ${isZh ? '说明' : 'description'}: ${isZh ? targetSlot.description_zh : targetSlot.description}\n`)
-          md.appendMarkdown(`#### ${isZh ? '插槽 props' : 'slotProps'}: \n`)
+          md.appendMarkdown(`**${target.lib} [${targetSlot.name}]**\n`)
+          md.appendMarkdown(`- ${isZh ? '说明' : 'description'}: ${isZh ? targetSlot.description_zh : targetSlot.description}\n`)
+          md.appendMarkdown(`**${isZh ? '插槽 props' : 'slotProps'}:** \n`)
           const typeString = `interface SlotProps ${params}`
           md.appendCodeblock(prettierType(typeString), 'typescript')
           return createHover(md)
@@ -823,7 +823,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const detail = getHoverAttribute(completions, propName)
         if (!detail)
           return
-        return createHover(`## Details \n\n${detail}`)
+        return createHover(`**Details** \n\n${detail}`)
       }
       // todo: 优化这里的条件,在 react 中, 也可以减少更多的处理步骤
       if (isVue()) {
@@ -845,7 +845,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 ;[...UiCompletions[refName].methods, ...UiCompletions[refName].exposed].forEach((m, i) => {
                 let content = typeof m.documentation === 'string' ? m.documentation : m.documentation?.value || ''
                 if (i !== 0) {
-                  content = content.replace(/##[^\]\n]*[\]\n]/, '')
+                  content = stripLeadingMarkdownTitle(content)
                 }
                 groupMd.appendMarkdown(content)
                 groupMd.appendMarkdown('\n')
@@ -881,7 +881,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 ;[...UiCompletions[refName].methods, ...UiCompletions[refName].exposed].forEach((m: any, i: number) => {
                 let content = m.documentation.value
                 if (content && i !== 0) {
-                  content = content.replace(/##[^\]\n]*[\]\n]/, '')
+                  content = stripLeadingMarkdownTitle(content)
                 }
                 groupMd.appendMarkdown(content)
                 groupMd.appendMarkdown('\n')
@@ -917,7 +917,7 @@ export async function activate(context: vscode.ExtensionContext) {
               ;[...UiCompletions[refName].methods, ...UiCompletions[refName].exposed].forEach((m, i) => {
               let content = typeof m.documentation === 'string' ? m.documentation : m.documentation?.value || ''
               if (i !== 0) {
-                content = content.replace(/##[^\]\n]*[\]\n]/, '')
+                content = stripLeadingMarkdownTitle(content)
               }
               groupMd.appendMarkdown(content)
               groupMd.appendMarkdown('\n')
@@ -960,6 +960,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export function deactivate() {
   deactivateUICache()
+}
+
+function stripLeadingMarkdownTitle(content: string) {
+  return content.replace(/^(?:##[^\n]*|\*\*[^\n]+?\*\*)\n*/, '')
 }
 
 function getEffectWord(preText: string) {

--- a/src/ui/utils.ts
+++ b/src/ui/utils.ts
@@ -133,36 +133,36 @@ export function propsReducer(options: PropsOptions) {
         documentation.supportHtml = true
         const detail = []
 
-        detail.push(`## ${uiName} [${item.name}]`)
+        detail.push(`**${uiName} [${item.name}]**`)
 
         if (value.default !== undefined && value.default !== '') {
           value.default = String(value.default)
-          detail.push(`#### 💎 ${isZh ? '默认值' : 'default'}:    ***\`${value.default.replace(/[`\n]/g, '')}\`***`)
+          detail.push(`- 💎 ${isZh ? '默认值' : 'default'}:    ***\`${value.default.replace(/[`\n]/g, '')}\`***`)
         }
 
         if (value.version) {
           if (isZh)
-            detail.push(`#### 🚀 版本:    ***\`${value.version}\`***`)
+            detail.push(`- 🚀 版本:    ***\`${value.version}\`***`)
           else
-            detail.push(`#### 🚀 version:    ***\`${value.version}\`***`)
+            detail.push(`- 🚀 version:    ***\`${value.version}\`***`)
         }
 
         if (value.platform) {
-          detail.push(`#### 🚀 平台:   ***\`${value.platform}\`***`)
+          detail.push(`- 🚀 平台:   ***\`${value.platform}\`***`)
         }
 
         if (value.description) {
           if (isZh)
-            detail.push(`#### 🔦 说明:    ***\`${value.description_zh || value.description}\`***`)
+            detail.push(`- 🔦 说明:    ***\`${value.description_zh || value.description}\`***`)
           else
-            detail.push(`#### 🔦 description:    ***\`${value.description}\`***`)
+            detail.push(`- 🔦 description:    ***\`${value.description}\`***`)
         }
 
         if (value.type) {
           if (Array.isArray(value.type)) {
             value.type = value.type.join(' / ')
           }
-          detail.push(`#### 💡 ${isZh ? '类型' : 'type'}:    ***\`${value.type.replace(/`/g, '')}\`***`)
+          detail.push(`- 💡 ${isZh ? '类型' : 'type'}:    ***\`${value.type.replace(/`/g, '')}\`***`)
         }
 
         documentation.appendMarkdown(detail.join('\n\n'))
@@ -342,20 +342,20 @@ export function propsReducer(options: PropsOptions) {
           const detail: string[] = []
           const { name, description, params, description_zh, platform } = events
 
-          detail.push(`## ${uiName} [${item.name}]`)
+          detail.push(`**${uiName} [${item.name}]**`)
 
           if (description) {
             if (isZh)
-              detail.push(`#### 🔦 说明:    ***\`${description_zh || description}\`***`)
+              detail.push(`- 🔦 说明:    ***\`${description_zh || description}\`***`)
             else
-              detail.push(`#### 🔦 description:    ***\`${description}\`***`)
+              detail.push(`- 🔦 description:    ***\`${description}\`***`)
           }
 
           if (platform)
-            detail.push(`#### 🚀 平台:    ***\`${platform}\`***`)
+            detail.push(`- 🚀 平台:    ***\`${platform}\`***`)
 
           if (params)
-            detail.push(`#### 🔮 ${isZh ? '回调参数' : 'callback parameters'}:    ***\`${params}\`***`)
+            detail.push(`- 🔮 ${isZh ? '回调参数' : 'callback parameters'}:    ***\`${params}\`***`)
 
           let snippet
           let content
@@ -418,10 +418,10 @@ export function propsReducer(options: PropsOptions) {
         const detail: string[] = []
         const { name, description, params, description_zh } = method
 
-        detail.push(`## ${uiName} [${item.name}]`)
+        detail.push(`**${uiName} [${item.name}]**`)
 
         if (name)
-          detail.push(`\n#### 💨 ${isZh ? '方法' : 'method'} ${name}:`)
+          detail.push(`\n- 💨 ${isZh ? '方法' : 'method'} ${name}:`)
 
         if (description) {
           if (isZh)
@@ -454,10 +454,10 @@ export function propsReducer(options: PropsOptions) {
         const details: string[] = []
         const { name, description, detail, description_zh } = expose
 
-        details.push(`## ${uiName} [${item.name}]`)
+        details.push(`**${uiName} [${item.name}]**`)
 
         if (name)
-          details.push(`\n#### 💨 ${isZh ? '导出' : 'exposed'} ${name}:`)
+          details.push(`\n- 💨 ${isZh ? '导出' : 'exposed'} ${name}:`)
 
         if (description) {
           if (isZh)
@@ -506,7 +506,7 @@ export function propsReducer(options: PropsOptions) {
       documentation.isTrusted = true
       documentation.supportHtml = true
       const details: string[] = []
-      let text = `## ${uiName} [${item.name}]`
+      let text = `**${uiName} [${item.name}]**`
       if (item.link) {
         text += `\`            \`[🔗 ${isZh ? '文档链接' : 'Documentation link'}](command:intellisense.openDocument?%7B%22link%22%3A%22${encodeURIComponent(isZh ? (item?.link_zh || item.link) : item.link)}%22%7D)\`   \`[🔗 ${isZh ? '外部链接' : 'External document links'}](command:intellisense.openDocumentExternal?%7B%22link%22%3A%22${encodeURIComponent(isZh ? (item?.link_zh || item.link) : item.link)}%22%7D) \`            \` [🌟 Star!](https://github.com/common-intellisense/common-intellisense) \`            \` [❤️ Sponsor!](https://github.com/Simon-He95/sponsor)`
       }
@@ -514,9 +514,9 @@ export function propsReducer(options: PropsOptions) {
 
       if (item.props) {
         if (isZh)
-          details.push('### 参数:')
+          details.push('**参数:**')
         else
-          details.push('### Props:')
+          details.push('**Props:**')
 
         const tableHeader = `| ${isZh ? '属性名' : 'Name'} | ${isZh ? '描述' : 'Description'} | ${isZh ? '类型' : 'Type'} | ${isZh ? '默认值' : 'Default'} |`
         const tableDivider = '| --- | --- | --- | --- |'
@@ -539,9 +539,9 @@ export function propsReducer(options: PropsOptions) {
 
       if (item.methods && item.methods.length) {
         if (isZh)
-          details.push('## 方法:')
+          details.push('**方法:**')
         else
-          details.push('## Methods:')
+          details.push('**Methods:**')
 
         const tableHeader = `| ${isZh ? '方法名' : 'Method Name'} | ${isZh ? '描述' : 'Description'} | ${isZh ? '参数' : 'Params'} |`
         const tableDivider = '| --- | --- | --- |'
@@ -563,9 +563,9 @@ export function propsReducer(options: PropsOptions) {
 
       if (item.events && item.events.length) {
         if (isZh)
-          details.push('## 事件:')
+          details.push('**事件:**')
         else
-          details.push('## Events:')
+          details.push('**Events:**')
 
         const tableHeader = `| ${isZh ? '事件名' : 'Event Name'} | ${isZh ? '描述' : 'Description'} | ${isZh ? '参数' : 'Params'} |`
         const tableDivider = '| --- | --- | --- |'
@@ -587,9 +587,9 @@ export function propsReducer(options: PropsOptions) {
 
       if (item.slots && item.slots.length) {
         if (isZh)
-          details.push('## 插槽:')
+          details.push('**插槽:**')
         else
-          details.push('## Slots:')
+          details.push('**Slots:**')
 
         const tableHeader = `| ${isZh ? '插槽名' : 'Slot Name'} | ${isZh ? '描述' : 'Description'} |`
         const tableDivider = '| --- | --- |'
@@ -697,14 +697,14 @@ export function componentsReducer(options: ComponentOptions): ComponentsConfig {
           documentation.isTrusted = true
           documentation.supportHtml = true
 
-          documentation.appendMarkdown(`#### 🍀 ${lib} ${detail}\n`)
+          documentation.appendMarkdown(`**🍀 ${lib} ${detail}**\n`)
           if (typeof content === 'object' && content.suggestions?.length) {
-            documentation.appendMarkdown(`\n#### 👗 ${isZh ? '常用搭配' : 'Common collocation'} \n`)
+            documentation.appendMarkdown(`\n**👗 ${isZh ? '常用搭配' : 'Common collocation'}** \n`)
             // FIXME: suggestions的Item有对象形式的vant4里面,里面的文案要怎么展示
             documentation.appendMarkdown(`${content.suggestions.map((item: string | SuggestionItem) => `- ${item}`).join('\n')}\n`)
           }
           const copyIcon = '<img width="12" height="12" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxnIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2UyOWNkMCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2Utd2lkdGg9IjEuNSI+PHBhdGggZD0iTTIwLjk5OCAxMGMtLjAxMi0yLjE3NS0uMTA4LTMuMzUzLS44NzctNC4xMjFDMTkuMjQzIDUgMTcuODI4IDUgMTUgNWgtM2MtMi44MjggMC00LjI0MyAwLTUuMTIxLjg3OUM2IDYuNzU3IDYgOC4xNzIgNiAxMXY1YzAgMi44MjggMCA0LjI0My44NzkgNS4xMjFDNy43NTcgMjIgOS4xNzIgMjIgMTIgMjJoM2MyLjgyOCAwIDQuMjQzIDAgNS4xMjEtLjg3OUMyMSAyMC4yNDMgMjEgMTguODI4IDIxIDE2di0xIi8+PHBhdGggZD0iTTMgMTB2NmEzIDMgMCAwIDAgMyAzTTE4IDVhMyAzIDAgMCAwLTMtM2gtNEM3LjIyOSAyIDUuMzQzIDIgNC4xNzIgMy4xNzJDMy41MTggMy44MjUgMy4yMjkgNC43IDMuMTAyIDYiLz48L2c+PC9zdmc+" />'
-          documentation.appendMarkdown(`#### 🌰 ${isZh ? '例子' : 'example'}\n`)
+          documentation.appendMarkdown(`**🌰 ${isZh ? '例子' : 'example'}**\n`)
           documentation.appendCodeblock(demo, 'html')
           // FIXME: 要求输入数组，但是demo类型是字符串，但是都通过JSON.stringify处理了，所以这里转成[demo]?
           const params = setCommandParams(demo as any)
@@ -747,13 +747,13 @@ export function componentsReducer(options: ComponentOptions): ComponentsConfig {
           const documentation = new vscode.MarkdownString()
           documentation.isTrusted = true
           documentation.supportHtml = true
-          documentation.appendMarkdown(`#### 🍀 ${lib} ${detail}\n`)
+          documentation.appendMarkdown(`**🍀 ${lib} ${detail}**\n`)
           if (typeof content === 'object' && content.suggestions?.length) {
-            documentation.appendMarkdown(`\n#### 👗 ${isZh ? '常用搭配' : 'Common collocation'} \n`)
+            documentation.appendMarkdown(`\n**👗 ${isZh ? '常用搭配' : 'Common collocation'}** \n`)
             documentation.appendMarkdown(`${content.suggestions.map((item: string | SuggestionItem) => `- ${typeof item === 'string' ? item : item.name}`).join('\n')}\n`)
           }
           const copyIcon = '<img width="12" height="12" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxnIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2UyOWNkMCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2Utd2lkdGg9IjEuNSI+PHBhdGggZD0iTTIwLjk5OCAxMGMtLjAxMi0yLjE3NS0uMTA4LTMuMzUzLS44NzctNC4xMjFDMTkuMjQzIDUgMTcuODI4IDUgMTUgNWgtM2MtMi44MjggMC00LjI0MyAwLTUuMTIxLjg3OUM2IDYuNzU3IDYgOC4xNzIgNiAxMXY1YzAgMi44MjggMCA0LjI0My44NzkgNS4xMjFDNy43NTcgMjIgOS4xNzIgMjIgMTIgMjJoM2MyLjgyOCAwIDQuMjQzIDAgNS4xMjEtLjg3OUMyMSAyMC4yNDMgMjEgMTguODI4IDIxIDE2di0xIi8+PHBhdGggZD0iTTMgMTB2NmEzIDMgMCAwIDAgMyAzTTE4IDVhMyAzIDAgMCAwLTMtM2gtNEM3LjIyOSAyIDUuMzQzIDIgNC4xNzIgMy4xNzJDMy41MTggMy44MjUgMy4yMjkgNC43IDMuMTAyIDYiLz48L2c+PC9zdmc+" />'
-          documentation.appendMarkdown(`#### 🌰 ${isZh ? '例子' : 'example'}\n`)
+          documentation.appendMarkdown(`**🌰 ${isZh ? '例子' : 'example'}**\n`)
           documentation.appendCodeblock(demo, 'html')
           // FIXME: 同上
           const params = setCommandParams(demo as any)
@@ -803,13 +803,13 @@ export function componentsReducer(options: ComponentOptions): ComponentsConfig {
       const documentation = new vscode.MarkdownString()
       documentation.isTrusted = true
       documentation.supportHtml = true
-      documentation.appendMarkdown(`#### 🍀 ${lib} ${detail}\n`)
+      documentation.appendMarkdown(`**🍀 ${lib} ${detail}**\n`)
       if (typeof content === 'object' && content.suggestions?.length) {
-        documentation.appendMarkdown(`\n#### 👗 ${isZh ? '常用搭配' : 'Common collocation'} \n`)
+        documentation.appendMarkdown(`\n**👗 ${isZh ? '常用搭配' : 'Common collocation'}** \n`)
         documentation.appendMarkdown(`${content.suggestions.map((item: string | SuggestionItem) => `- ${typeof item === 'string' ? item : item.name}`).join('\n')}\n`)
       }
       const copyIcon = '<img width="12" height="12" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxnIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2UyOWNkMCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2Utd2lkdGg9IjEuNSI+PHBhdGggZD0iTTIwLjk5OCAxMGMtLjAxMi0yLjE3NS0uMTA4LTMuMzUzLS44NzctNC4xMjFDMTkuMjQzIDUgMTcuODI4IDUgMTUgNWgtM2MtMi44MjggMC00LjI0MyAwLTUuMTIxLjg3OUM2IDYuNzU3IDYgOC4xNzIgNiAxMXY1YzAgMi44MjggMCA0LjI0My44NzkgNS4xMjFDNy43NTcgMjIgOS4xNzIgMjIgMTIgMjJoM2MyLjgyOCAwIDQuMjQzIDAgNS4xMjEtLjg3OUMyMSAyMC4yNDMgMjEgMTguODI4IDIxIDE2di0xIi8+PHBhdGggZD0iTTMgMTB2NmEzIDMgMCAwIDAgMyAzTTE4IDVhMyAzIDAgMCAwLTMtM2gtNEM3LjIyOSAyIDUuMzQzIDIgNC4xNzIgMy4xNzJDMy41MTggMy44MjUgMy4yMjkgNC43IDMuMTAyIDYiLz48L2c+PC9zdmc+" />'
-      documentation.appendMarkdown(`#### 🌰 ${isZh ? '例子' : 'example'}\n`)
+      documentation.appendMarkdown(`**🌰 ${isZh ? '例子' : 'example'}**\n`)
       documentation.appendCodeblock(demo, 'html')
       // FIXME: setCommandParams要求 string[]
       const params = setCommandParams(demo as any)

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -4,12 +4,22 @@ import { vi } from 'vitest'
 vi.mock('@vscode-use/utils', () => ({
   createCompletionItem: (options: any) => ({ ...options }),
   createHover: (documentation: any) => ({ documentation }),
-  createMarkdownString: () => ({
-    isTrusted: false,
-    supportHtml: false,
-    appendMarkdown: () => {},
-    appendCodeblock: () => {},
-  }),
+  createMarkdownString: () => {
+    const markdown = {
+      value: '',
+      isTrusted: false,
+      supportHtml: false,
+      appendMarkdown(value: string) {
+        markdown.value += value
+        return markdown
+      },
+      appendCodeblock(value: string, language = '') {
+        markdown.value += `\n\`\`\`${language}\n${value}\n\`\`\`\n`
+        return markdown
+      },
+    }
+    return markdown
+  },
   createRange: () => ({}),
   getActiveText: vi.fn(() => ''),
   getActiveTextEditor: () => null,
@@ -54,10 +64,23 @@ vi.mock('@vscode-use/utils', () => ({
 // Mock 'vscode' to avoid needing the real VSCode runtime in unit tests.
 vi.mock('vscode', () => {
   class MarkdownString {
+    value = ''
     isTrusted = false
     supportHtml = false
-    appendMarkdown(_s: string) {}
-    appendCodeblock(_s: string, _lang?: string) {}
+
+    constructor(value = '') {
+      this.value = value
+    }
+
+    appendMarkdown(value: string) {
+      this.value += value
+      return this
+    }
+
+    appendCodeblock(value: string, language = '') {
+      this.value += `\n\`\`\`${language}\n${value}\n\`\`\`\n`
+      return this
+    }
   }
   class Range {}
   return {

--- a/test/ui/issue-41.test.ts
+++ b/test/ui/issue-41.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { componentsReducer, propsReducer } from '../../src/ui/utils'
+
+const headingPattern = /^#{2,4}\s/m
+
+function expectNoLargeMarkdownHeading(value: string | undefined) {
+  expect(value).toBeDefined()
+  expect(value).not.toMatch(headingPattern)
+}
+
+function markdownValue(documentation: any) {
+  return typeof documentation === 'string' ? documentation : documentation?.value
+}
+
+describe('issue 41 UI markdown formatting', () => {
+  it('does not use large markdown headings in hover and completion documentation', async () => {
+    const result = await propsReducer({
+      uiName: 'fixture',
+      lib: '__missing_package__',
+      map: [{
+        name: 'DemoButton',
+        props: {
+          disabled: {
+            default: 'false',
+            value: '',
+            type: 'boolean',
+            description: 'Disable the button',
+          },
+        },
+        events: [
+          { name: 'click', description: 'Click event', params: 'MouseEvent' },
+        ],
+        methods: [
+          { name: 'focus', description: 'Focus button', params: '()' },
+        ],
+        exposed: [
+          { name: 'blur', detail: '()', description: 'Blur button' },
+        ],
+        slots: [
+          { name: 'default', description: 'Default slot' },
+        ],
+      }],
+    })
+
+    const demoButton = result.DemoButton
+    const propCompletion = demoButton.completions[0](true).find(item => (item as any).params?.[1] === 'disabled')
+    const eventCompletion = demoButton.events[0](true).find(item => (item as any).params?.[1] === 'click')
+
+    expectNoLargeMarkdownHeading(demoButton.tableDocument.value)
+    expectNoLargeMarkdownHeading(markdownValue(propCompletion?.documentation))
+    expectNoLargeMarkdownHeading(markdownValue(eventCompletion?.documentation))
+    expectNoLargeMarkdownHeading(markdownValue(demoButton.methods[0].documentation))
+    expectNoLargeMarkdownHeading(markdownValue(demoButton.exposed[0].documentation))
+  })
+
+  it('does not use large markdown headings in component completion documentation', async () => {
+    const [config] = componentsReducer({
+      lib: 'fixture-lib',
+      map: [[{ name: 'DemoButton', description: 'Demo button' }, 'Demo detail']],
+    })
+
+    const [completion] = await Promise.all(config.data())
+
+    expectNoLargeMarkdownHeading(markdownValue(completion.documentation))
+  })
+})


### PR DESCRIPTION
## Summary
- Replace large Markdown headings in hover and completion docs with compact bold labels/list items.
- Keep ref method aggregation deduplication working with both old and new heading formats.
- Add an issue 41 regression test that checks generated Markdown no longer contains large heading markers.

## Tests
- `pnpm -s run typecheck`
- `pnpm -s exec vitest run`
- `pnpm -s run lint`
- pre-commit Vitest run

Closes #41