### PR TITLE
chore: exclude dev files from extension package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,3 +5,11 @@ test
 .vscode
 assets
 scripts
+examples
+.husky
+.gitignore
+.eslintcache
+eslint.config.js
+pnpm*.yaml
+tsup.config.ts
+vitest.config.mjs


### PR DESCRIPTION
## Summary
- Exclude examples and dev-only config files from the VS Code extension package
- Keep the packaged extension focused on runtime files

## Verification
- `pnpm exec vsce ls --no-dependencies | rg '^(examples/|\.husky/|\.gitignore$|\.eslintcache$|eslint\.config\.js$|pnpm.*\.yaml$|tsup\.config\.ts$|vitest\.config\.mjs$)'`
- `pnpm exec vsce package --no-dependencies --out /tmp/common-intellisense-pr-44.vsix` -> 20 files, 2.21 MB

Closes #44